### PR TITLE
(PrepScreenGuide) Fix Start button opening guide instead of starting map

### DIFF
--- a/src/PrepScreenGuide/PrepScreenGuide.event
+++ b/src/PrepScreenGuide/PrepScreenGuide.event
@@ -55,26 +55,11 @@ PUSH
         callHack_r1(PrepScreenGuide_MapMenu_AddExtraEntry|1)
         SHORT 0x46C0 // NOP
 
-    ORG 0x59E00C // Replaces the part of SALLYCURSOR proc where Merlinus would show up in FE7; nulled out in FE8
+    ORG 0x59DF84 // Replaces the part of SALLYCURSOR proc where the Chapter Status screen would be started, but it's unused in vanilla
     {
-        #define BMapDispSuspend            0x08030184
-        #define ClosePrepScreenMapMenu     0x0803334C
-        #define BMapDispResume             0x080301B8
-
-        PROC_CALL_ROUTINE(BMapDispSuspend|1)
-        PROC_CALL_ROUTINE(ClosePrepScreenMapMenu|1)
-
         PROC_CALL_ROUTINE(PrepScreenGuide_StartGuide|1)
-        PROC_YIELD
-
-        PROC_CALL_ROUTINE(BMapDispResume|1)
-
-        PROC_GOTO(62)
-
-        #undef BMapDispSuspend
-        #undef ClosePrepScreenMapMenu
-        #undef BMapDispResume
     }
+
 POP
 
 #endif /* PREP_SCREEN_GUIDE_INSTALLED */

--- a/src/PrepScreenGuide/src/PrepScreenGuide.c
+++ b/src/PrepScreenGuide/src/PrepScreenGuide.c
@@ -8,6 +8,8 @@
 #include "m4a.h"
 #include "soundwrapper.h"
 
+#include "constants/msg.h"
+
 #include "../../Text/TextDefinitions.h"
 
 void Guide_Init(ProcPtr);
@@ -80,8 +82,8 @@ const struct ProcCmd ProcScr_PrepScreenGuide[] = {
 // MAIN PREP MENU
 // ==================================
 
-// Autohook this function, we don't need it (vanilla function for calling chapter status screen from prep)
-void sub_808E79C(ProcPtr proc) {
+// Fully replace this function (FE8U:0x0808E79C); it's not used in vanilla
+void StartChapterStatusScreen_FromPrep(ProcPtr proc) {
     Proc_StartBlocking(ProcScr_PrepScreenGuide, proc);
     return;
 }
@@ -104,7 +106,7 @@ void PrepScreenGuide_AddExtraEntry(struct ProcAtMenu * proc) {
         color = TEXT_COLOR_SYSTEM_GRAY;
     }
 
-    SetPrepScreenMenuItem(PREP_MAINMENU_SAVE, PrepScreenMenu_OnSave, color, 0x579, 0);
+    SetPrepScreenMenuItem(PREP_MAINMENU_SAVE, PrepScreenMenu_OnSave, color, MSG_579, 0);
 
     color = TEXT_COLOR_SYSTEM_WHITE;
     if (IsGuideLocked()) {
@@ -123,20 +125,20 @@ void PrepScreenGuide_AddExtraEntry(struct ProcAtMenu * proc) {
 
 void PrepScreenGuide_MapMenu_OnGuide(struct ProcPrepSallyCursor * proc) {
     proc->unk_58 = 4;
-    Proc_Goto(proc, 55); // Take over the Merlinus intro cutscene in the Sallycursor proc
+    Proc_Goto(proc, 56); // Take over the unused Chapter Status section in the Sallycursor proc
     return;
 }
 
 // hook at 0x33696 (PrepScreenProc_StartMapMenu)
 void PrepScreenGuide_MapMenu_AddExtraEntry(struct ProcPrepSallyCursor * proc) {
     // Preserve what we've replaced
-    SetPrepScreenMenuItem(8, PrepMapMenu_OnOptions, 0, 0x592, 0x5BD);
+    SetPrepScreenMenuItem(8, PrepMapMenu_OnOptions, TEXT_COLOR_SYSTEM_WHITE, MSG_592, MSG_5BD);
 
     // 0x06E5 = vanilla Guide help text ID
     if (!IsGuideLocked()) {
-        SetPrepScreenMenuItem(4, PrepScreenGuide_MapMenu_OnGuide, TEXT_COLOR_SYSTEM_WHITE, Guide_PrepMenu_Text, 0x06E5);
+        SetPrepScreenMenuItem(4, PrepScreenGuide_MapMenu_OnGuide, TEXT_COLOR_SYSTEM_WHITE, Guide_PrepMenu_Text, MSG_6E5);
     } else {
-        SetPrepScreenMenuItem(4, PrepScreenGuide_MapMenu_OnGuide, TEXT_COLOR_SYSTEM_GRAY, Guide_PrepMenu_Text, 0x06E5);
+        SetPrepScreenMenuItem(4, PrepScreenGuide_MapMenu_OnGuide, TEXT_COLOR_SYSTEM_GRAY, Guide_PrepMenu_Text, MSG_6E5);
     }
 
     return;


### PR DESCRIPTION
Fixes an issue where pressing the Start button on the prep screen map menu caused the Guide to start instead of ending the prep phase and starting the map.

I made a mistake when taking over the part of the `SALLYCURSOR` proc (around proc label 55 in vanilla).

There were empty/undocumented functions around proc label 55 in FE8 that I thought at the time would be safe to overwrite because they were leftover from some event handlers for Merlinus in the FE7 equivalent. After reviewing the logic flow, it looks like that area is actually used in FE8.

[`PrepMapMenu_OnStartPress`](https://github.com/FireEmblemUniverse/fireemblem8u/blob/fca5f90afc47950a8bf5ab2af536d487d5fbb584/src/prep_sallycursor.c#L444) (`FE8U:0x080333A4`) goes to proc label 55 of `SALLYCURSOR`, which calls the dummied-out function `nullsub_20` (which is what I thought was left over from Merlinus logic) and then calls `sub_801240C` (which does seem to be important for loading in blue-aligned units that are force deployed if I'm reading it right?), then ends the prep screen.

This PR instead takes over the functionality for starting the status screen from the prep menu, which is not used in vanilla. From research, it seems that its proc label is completely unused.